### PR TITLE
AWS QLDB notice

### DIFF
--- a/content/news/getting-started.md
+++ b/content/news/getting-started.md
@@ -4,7 +4,9 @@ date: 2022-01-01
 include_footer: true
 ---
 
-## _“It's not you – it's me”_
+> **⚠️ Deprecation Warning:** This guide references AWS QLDB, which will reach end of support on July 31, 2025. AWS is no longer accepting new QLDB users. Please contact us at hi@digitalevidencetoolkit.org for updated setup instructions using alternative immutable storage solutions.
+
+## _"It's not you – it's me"_
 
 If the instructions in this guide feel a bit much, it's likely because the Toolkit is still an alpha-version software which assumes a certain technical knowledge. There are technical solutions to simplifying this setup, but these were not prioritised.
 

--- a/content/tools/original-dept-prototype.md
+++ b/content/tools/original-dept-prototype.md
@@ -3,6 +3,8 @@ title: "Original DEPToolkit prototype"
 date: 2021-12-31
 ---
 
+> **📚 Historical Documentation:** This page documents the original DEPToolkit prototype. Please note that AWS QLDB, which was used in this implementation, has been deprecated and will reach end of support on July 31, 2025. For current solutions, see our [web archiving tools](/tools/webpage-archiving).
+
 Welcome to the documentation of the Digital Evidence Preservation Toolkit, a one-click tool to archive and annotate webpages while demonstrating chain of custody throughout. The Toolkit is a proof-of-concept software for researchers and small teams sifting through online material.
 
 With only one click of the mouse, the material will be **archived in a framework demonstrating chain of custody** and **stored durably**. Once included in the growing database, users will be able to **go back to search through** and **annotate the material**, and to **export working copies** of said material for publication and dissemination.

--- a/content/tools/webpage-archiving.md
+++ b/content/tools/webpage-archiving.md
@@ -3,6 +3,8 @@ title: "Archive Webpages with Proof of Integrity"
 date: 2024-06-01
 ---
 
+> **⚠️ Important Notice:** AWS QLDB, one of the storage backends mentioned in this documentation, will reach end of support on July 31, 2025. We recommend using alternative immutable storage solutions. For more information, see [AWS documentation](https://docs.aws.amazon.com/qldb/latest/developerguide/document-history.html).
+
 The Digital Evidence Preservation Toolkit (DEPT) offers a seamless way to capture and authenticate web content while ensuring a verifiable chain of custody. Our one-click browser extension allows you to archive webpages with cryptographic proof, making them admissible in legal, journalistic, and research contexts.
 
 Every saved webpage is stored alongside metadata, DNS records, in tamper-evident data structures, ensuring long-term integrity. Whether you’re investigating misinformation, documenting critical online evidence, or preserving web pages for compliance, our solution guarantees authenticity you can trust.


### PR DESCRIPTION
AWS QLDB will reach end of support on July 31, 2025. Added deprecation warnings to:
- webpage-archiving.md: Notice about alternative storage solutions
- original-dept-prototype.md: Historical documentation note
- getting-started.md: Warning for new users to contact for alternatives

