### PR TITLE
Fix inconsistent line heights with footnote marks

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -238,4 +238,16 @@
   .post-date {
     font-style: normal;
   }
+
+  /* Fix footnote superscript line height issue */
+  sup {
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+    top: -0.5em;
+  }
+
+  .footnote-ref {
+    line-height: 0;
+  }
 </style>


### PR DESCRIPTION
Prevent footnote reference marks from affecting line height by:
- Setting line-height: 0 on sup elements
- Using relative positioning with baseline alignment
- Adjusting vertical position with top: -0.5em

This ensures lines with footnote marks maintain the same height as lines without them, creating consistent vertical rhythm throughout the text.